### PR TITLE
fixed problem that crashes when using React Navigation v3

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { createStackNavigator } from 'react-navigation'
+import { createStackNavigator, createAppContainer } from 'react-navigation'
 
 import LoginScreen from './screens/LoginScreen'
 import HomeScreen from './screens/HomeScreen'
 export default class App extends React.Component {
   render() {
     return (
-      <AppStackNavigator />
+      <AppContainer />
     );
   }
 }
@@ -17,6 +17,8 @@ const AppStackNavigator = createStackNavigator({
   Home: HomeScreen
 
 })
+    
+const AppContainer = createAppContainer(AppStackNavigator);
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
As of v3, required to use the container directly. In v3 renamed createNavigationContainer to createAppContainer.